### PR TITLE
feat(animated-clock): Add timezone selector for global time display

### DIFF
--- a/projects/animated-clock/index.html
+++ b/projects/animated-clock/index.html
@@ -10,8 +10,27 @@
 
 <body>
     <main>
-        <h1>Animated Clock</h1><canvas id="clock" width="240" height="240"></canvas>
-        <p class="notes">Smooth animation with requestAnimationFrame.</p>
+        <h1>Animated Clock</h1>
+        <div class="controls">
+            <label for="timezone-select">Time Zone:</label>
+            <select id="timezone-select" aria-label="Select time zone">
+                <option value="local">Local Time</option>
+                <option value="UTC">UTC</option>
+                <option value="America/New_York">New York</option>
+                <option value="America/Los_Angeles">Los Angeles</option>
+                <option value="America/Chicago">Chicago</option>
+                <option value="Europe/London">London</option>
+                <option value="Europe/Paris">Paris</option>
+                <option value="Europe/Berlin">Berlin</option>
+                <option value="Asia/Tokyo">Tokyo</option>
+                <option value="Asia/Shanghai">Shanghai</option>
+                <option value="Asia/Kolkata">Mumbai</option>
+                <option value="Australia/Sydney">Sydney</option>
+                <option value="Pacific/Auckland">Auckland</option>
+            </select>
+        </div>
+        <canvas id="clock" width="240" height="240"></canvas>
+        <p class="notes">Smooth animation with requestAnimationFrame. Select a time zone to view different regional times.</p>
     </main>
     <script type="module" src="./main.js"></script>
 </body>

--- a/projects/animated-clock/main.js
+++ b/projects/animated-clock/main.js
@@ -1,9 +1,63 @@
-const c = document.getElementById('clock'); const ctx = c.getContext('2d');
+const c = document.getElementById('clock');
+const ctx = c.getContext('2d');
+const timezoneSelect = document.getElementById('timezone-select');
+
+let selectedTimezone = 'local';
+
+timezoneSelect.addEventListener('change', (e) => {
+    selectedTimezone = e.target.value;
+});
+
+function getCurrentTime() {
+    const now = new Date();
+    if (selectedTimezone === 'local') {
+        return now;
+    }
+    
+    try {
+        const timeInTimezone = new Date(now.toLocaleString("en-US", {timeZone: selectedTimezone}));
+        const localTime = new Date(now.toLocaleString("en-US"));
+        const diff = localTime.getTime() - timeInTimezone.getTime();
+        return new Date(now.getTime() - diff);
+    } catch (error) {
+        return now;
+    }
+}
+
 function draw() {
-    const now = new Date(); const w = c.width, h = c.height, r = w / 2; ctx.clearRect(0, 0, w, h); ctx.translate(r, r); ctx.strokeStyle = '#93c5fd'; ctx.beginPath(); ctx.arc(0, 0, r - 6, 0, Math.PI * 2); ctx.stroke(); function hand(angle, len, width) { ctx.save(); ctx.rotate(angle); ctx.beginPath(); ctx.lineWidth = width; ctx.moveTo(0, 0); ctx.lineTo(0, -len); ctx.stroke(); ctx.restore(); }
-    const sec = now.getSeconds() + now.getMilliseconds() / 1000; const min = now.getMinutes() + sec / 60; const hr = ((now.getHours() % 12) + min / 60);
-    hand(hr * Math.PI / 6, r * 0.5, 4); hand(min * Math.PI / 30, r * 0.75, 3); hand(sec * Math.PI / 30, r * 0.85, 1);
+    const now = getCurrentTime();
+    const w = c.width, h = c.height, r = w / 2;
+    
+    ctx.clearRect(0, 0, w, h);
+    ctx.translate(r, r);
+    ctx.strokeStyle = '#93c5fd';
+    ctx.beginPath();
+    ctx.arc(0, 0, r - 6, 0, Math.PI * 2);
+    ctx.stroke();
+    
+    function hand(angle, len, width) {
+        ctx.save();
+        ctx.rotate(angle);
+        ctx.beginPath();
+        ctx.lineWidth = width;
+        ctx.moveTo(0, 0);
+        ctx.lineTo(0, -len);
+        ctx.stroke();
+        ctx.restore();
+    }
+    
+    const sec = now.getSeconds() + now.getMilliseconds() / 1000;
+    const min = now.getMinutes() + sec / 60;
+    const hr = ((now.getHours() % 12) + min / 60);
+    
+    hand(hr * Math.PI / 6, r * 0.5, 4);
+    hand(min * Math.PI / 30, r * 0.75, 3);
+    hand(sec * Math.PI / 30, r * 0.85, 1);
+    
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     requestAnimationFrame(draw);
 }
-ctx.strokeStyle = '#6ee7b7'; ctx.lineCap = 'round'; draw();
+
+ctx.strokeStyle = '#6ee7b7';
+ctx.lineCap = 'round';
+draw();

--- a/projects/animated-clock/styles.css
+++ b/projects/animated-clock/styles.css
@@ -10,7 +10,8 @@ body {
 
 main {
     max-width: 560px;
-    width: 100%
+    width: 100%;
+    text-align: center;
 }
 
 canvas {
@@ -19,7 +20,68 @@ canvas {
     border-radius: .5rem
 }
 
+.controls {
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.controls label {
+    font-weight: 500;
+    color: #eef1f8;
+}
+
+.controls select {
+    background: #17171c;
+    border: 1px solid #262631;
+    border-radius: 0.375rem;
+    color: #eef1f8;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.9rem;
+    min-width: 140px;
+    cursor: pointer;
+    transition: border-color 0.2s ease;
+}
+
+.controls select:hover {
+    border-color: #93c5fd;
+}
+
+.controls select:focus {
+    outline: none;
+    border-color: #6ee7b7;
+    box-shadow: 0 0 0 2px rgba(110, 231, 183, 0.2);
+}
+
 .notes {
     color: #a6adbb;
-    font-size: .9rem
+    font-size: .9rem;
+    margin-top: 1rem;
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 1rem;
+    }
+    
+    .controls {
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+    }
+    
+    .controls select {
+        min-width: 200px;
+        width: 100%;
+        max-width: 280px;
+    }
+    
+    canvas {
+        width: 100%;
+        max-width: 240px;
+        height: auto;
+    }
 }


### PR DESCRIPTION
## Summary

Added a timezone selector to the Animated Clock project, allowing users to view the clock in multiple regions. Updated logic to dynamically adjust time using the selected timezone. Improved UI styling for responsiveness and accessibility across devices.

## Checklist
- [x] Linked issue (if any)
- [x] Ran locally without console errors
- [x] Focused scope (kept PR small)
- [x] Updated docs or TODO comments if needed

## Screenshots
Before:
<img width="1686" height="897" alt="image" src="https://github.com/user-attachments/assets/07045986-000f-46f6-90d6-b0f32bd24ee8" />

After:
<img width="1682" height="920" alt="image" src="https://github.com/user-attachments/assets/6c9b6cf7-5019-4d5d-9f61-84db294dc7ce" />


Closes #24 

