### PR TITLE
feat:add local storage to expense tracker

### DIFF
--- a/projects/expense-tracker/main.js
+++ b/projects/expense-tracker/main.js
@@ -1,71 +1,109 @@
- const form = document.getElementById('form');
-    const desc = document.getElementById('desc');
-    const amount = document.getElementById('amount');
-    const list = document.getElementById('list');
-    const chart = document.getElementById('chart').getContext('2d');
-    const exportBtn = document.getElementById('exportBtn');
+const form = document.getElementById('form');
+const desc = document.getElementById('desc');
+const amount = document.getElementById('amount');
+const list = document.getElementById('list');
+const chart = document.getElementById('chart').getContext('2d');
+const exportBtn = document.getElementById('exportBtn');
 
-    let items = [];
+// localStorage key
+const STORAGE_KEY = 'vanillaverse_expense_tracker_items';
 
-    form.addEventListener('submit', e => {
-      e.preventDefault();
-      items.push({
-        id: crypto.randomUUID(),
-        desc: desc.value,
-        amount: parseFloat(amount.value) || 0,
-        date: new Date().toLocaleDateString()
-      });
-      desc.value = '';
-      amount.value = '';
-      render();
-    });
+// Load items from localStorage on page load
+let items = loadFromStorage();
 
-    function render() {
-      list.innerHTML = '';
-      let total = 0;
-      for (const it of items) {
-        total += it.amount;
-        const li = document.createElement('li');
-        li.textContent = `${it.date} — ${it.desc} — ₹${it.amount.toFixed(2)}`;
-        list.appendChild(li);
-      }
-      drawChart(total);
+// Load data from localStorage
+function loadFromStorage() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // Validate that it's an array
+      return Array.isArray(parsed) ? parsed : [];
     }
+  } catch (error) {
+    console.error('Error loading expenses from localStorage:', error);
+  }
+  return [];
+}
 
-    function drawChart(total) {
-      const w = 300, h = 150;
-      chart.clearRect(0, 0, w, h);
-      chart.fillStyle = '#17171c';
-      chart.fillRect(0, 0, w, h);
-      chart.fillStyle = '#6ee7b7';
-      chart.fillRect(0, h - (total % h), w, (total % h));
-    }
+// Save data to localStorage
+function saveToStorage() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch (error) {
+    console.error('Error saving expenses to localStorage:', error);
+    // Handle quota exceeded error
+    alert('Unable to save data. Storage may be full.');
+  }
+}
 
-    // --- CSV Export Feature ---
-    function exportCSV() {
-      if (items.length === 0) {
-        alert('No expenses to export!');
-        return;
-      }
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  items.push({
+    id: crypto.randomUUID(),
+    desc: desc.value,
+    amount: parseFloat(amount.value) || 0,
+    date: new Date().toLocaleDateString()
+  });
+  desc.value = '';
+  amount.value = '';
+  
+  // Save to localStorage after adding new item
+  saveToStorage();
+  
+  render();
+});
 
-      // Convert items to CSV format
-      const headers = ['Date', 'Description', 'Amount (INR)'];
-      const rows = items.map(it => [it.date, it.desc, it.amount]);
-      const csvContent = [headers, ...rows]
-        .map(row => row.map(val => `"${val}"`).join(','))
-        .join('\\n');
+function render() {
+  list.innerHTML = '';
+  let total = 0;
+  for (const it of items) {
+    total += it.amount;
+    const li = document.createElement('li');
+    li.textContent = `${it.date} — ${it.desc} — ₹${it.amount.toFixed(2)}`;
+    list.appendChild(li);
+  }
+  drawChart(total);
+}
 
-      // Create and trigger download
-      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `expenses-${new Date().toISOString().slice(0, 10)}.csv`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    }
+function drawChart(total) {
+  const w = 300, h = 150;
+  chart.clearRect(0, 0, w, h);
+  chart.fillStyle = '#17171c';
+  chart.fillRect(0, 0, w, h);
+  chart.fillStyle = '#6ee7b7';
+  chart.fillRect(0, h - (total % h), w, (total % h));
+}
 
-    exportBtn.addEventListener('click', exportCSV);
-    render();
+// --- CSV Export Feature ---
+function exportCSV() {
+  if (items.length === 0) {
+    alert('No expenses to export!');
+    return;
+  }
+
+  // Convert items to CSV format
+  const headers = ['Date', 'Description', 'Amount (INR)'];
+  const rows = items.map(it => [it.date, it.desc, it.amount]);
+  const csvContent = [headers, ...rows]
+    .map(row => row.map(val => `"${val}"`).join(','))
+    .join('\n');
+
+  // Create and trigger download
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `expenses-${new Date().toISOString().slice(0, 10)}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+exportBtn.addEventListener('click', exportCSV);
+
+// Initial render with loaded data
+render();
+
+console.log(`Expense Tracker loaded with ${items.length} expense(s) from storage`);


### PR DESCRIPTION
closes issue #67 

## Summary

Describe your changes clearly.
Implements localStorage persistence for the Expense Tracker, ensuring user data persists across browser sessions.

## 🔧 Changes Made
- Added `loadFromStorage()` function to load expenses from localStorage on page load
- Added `saveToStorage()` function to persist data after adding new expenses
- Modified `items` initialization to load from localStorage with fallback to empty array
- Added error handling for localStorage operations (quota exceeded, parsing errors)
- **Bonus**: Fixed CSV export bug (newline character)

## Checklist
- [x] Linked issue (if any)
- [x] Ran locally without console errors
- [x] Focused scope (kept PR small)
- [x] Updated docs or TODO comments if needed

